### PR TITLE
feat: add patch to fix undefined symbol of liberofsfuse

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+erofs-utils (1.7.1-1deepin2) unstable; urgency=medium
+
+  * add patch to fix undefined symbol of liberofsfuse
+
+ -- ComixHe <heyuming@deepin.org>  Tue, 11 Jun 2024 11:56:29 +0800
+
 erofs-utils (1.7.1-1deepin1) unstable; urgency=medium
 
   * add patch to provide static library 'liberofsfuse.a'

--- a/debian/patches/0002-fix-undifined-symbols-duing-linking-liberofsfuse.patch
+++ b/debian/patches/0002-fix-undifined-symbols-duing-linking-liberofsfuse.patch
@@ -1,0 +1,32 @@
+From e4c10b5436d8fc415e0451ded70cf9d77b32a987 Mon Sep 17 00:00:00 2001
+From: ComixHe <heyuming@deepin.org>
+Date: Tue, 11 Jun 2024 12:02:30 +0800
+Subject: [PATCH] fix: undifined symbols duing linking liberofsfuse
+
+Signed-off-by: ComixHe <heyuming@deepin.org>
+---
+ fuse/Makefile.am | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/fuse/Makefile.am b/fuse/Makefile.am
+index 5d4d3b1..f4f3a7b 100644
+--- a/fuse/Makefile.am
++++ b/fuse/Makefile.am
+@@ -10,10 +10,10 @@ erofsfuse_LDADD = $(top_builddir)/lib/liberofs.la ${libfuse_LIBS} ${liblz4_LIBS}
+ 	${libselinux_LIBS} ${liblzma_LIBS} ${zlib_LIBS} ${libdeflate_LIBS}
+ 
+ if ENABLE_STATIC_FUSE
+-lib_LIBRARIES = liberofsfuse.a
+-liberofsfuse_a_SOURCES = main.c
+-liberofsfuse_a_CFLAGS  = -Wall -I$(top_srcdir)/include
+-liberofsfuse_a_CFLAGS += -Dmain=erofsfuse_main -DFUSE_USE_VERSION=26 ${libfuse_CFLAGS} ${libselinux_CFLAGS}
++lib_LTLIBRARIES = liberofsfuse.la
++liberofsfuse_la_SOURCES = main.c
++liberofsfuse_la_CFLAGS  = -Wall -I$(top_srcdir)/include
++liberofsfuse_la_CFLAGS += -Dmain=erofsfuse_main -DFUSE_USE_VERSION=26 ${libfuse_CFLAGS} ${libselinux_CFLAGS}
+ liberofsfuse_la_LIBADD  = $(top_builddir)/lib/liberofs.la ${libfuse_LIBS} ${liblz4_LIBS} \
+     ${libselinux_LIBS} ${liblzma_LIBS} ${zlib_LIBS} ${libdeflate_LIBS}
+ endif
+-- 
+2.45.2
+

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,1 +1,2 @@
 0001-build-support-building-static-library-liberofsfuse.patch
+0002-fix-undifined-symbols-duing-linking-liberofsfuse.patch

--- a/debian/rules
+++ b/debian/rules
@@ -32,5 +32,8 @@ override_dh_auto_install:
 	dh_auto_install
 	/bin/bash ./libtool --finish $(CURDIR)/debian/tmp/usr/lib/$(DEB_HOST_MULTIARCH)/
 
+	rm -r $(CURDIR)/debian/tmp/usr/lib/$(DEB_HOST_MULTIARCH)/liberofsfuse.la
+	rm -r $(CURDIR)/debian/tmp/usr/lib/$(DEB_HOST_MULTIARCH)/liberofsfuse.so*
+
 override_dh_missing:
 	dh_missing --fail-missing


### PR DESCRIPTION
upstream reject export liberofs due to liberofs is unstable and plan to address this in the future (v1.9)

linglong really need this to support exporting uab, so add this patch just for now, these patches will be removed after upstream erofs-utils releaseing v1.9

mail Link: https://lore.kernel.org/all/c534d8b0-906e-4f98-9b23-cfc55b4a10e3@linux.alibaba.com/T/#m262899d58613e1a2cdebd4f83b526a9d2dfdaece